### PR TITLE
ENTESB-10359 Add profile for productization-specific yarn config/setup/install

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -14,44 +14,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.github.eirslett</groupId>
-                <artifactId>frontend-maven-plugin</artifactId>
-                <executions>
-                    <!-- Install Node and Yarn -->
-                    <execution>
-                        <id>install node and yarn</id>
-                        <goals>
-                            <goal>install-node-and-yarn</goal>
-                        </goals>
-                        <configuration>
-                            <nodeVersion>v6.11.2</nodeVersion>
-                            <yarnVersion>v1.3.2</yarnVersion>
-                        </configuration>
-                    </execution>
-                    <!-- Install npm/yarn dependencies -->
-                    <execution>
-                        <id>yarn install</id>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                        <configuration>
-                            <arguments>install</arguments>
-                        </configuration>
-                    </execution>
-                    <!-- Build the app -->
-                    <execution>
-                        <id>ng build</id>
-                        <goals>
-                            <goal>yarn</goal>
-                        </goals>
-                        <phase>generate-resources</phase>
-                        <configuration>
-                            <arguments>build</arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
@@ -66,6 +28,7 @@
                             <descriptors>
                                 <descriptor>src/assembly/unix-dist.xml</descriptor>
                             </descriptors>
+                            <tarLongFileMode>posix</tarLongFileMode>
                         </configuration>
                     </execution>
                 </executions>
@@ -128,6 +91,151 @@
 
     <profiles>
         <profile>
+            <id>noproxy</id>
+            <activation>
+                <property>
+                    <name>!productization</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <executions>
+                            <!-- Install Node and Yarn -->
+                            <execution>
+                                <id>install node and yarn</id>
+                                <goals>
+                                    <goal>install-node-and-yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <nodeVersion>v6.11.2</nodeVersion>
+                                    <yarnVersion>v1.3.2</yarnVersion>
+                                </configuration>
+                            </execution>
+                            <!-- Install npm/yarn dependencies -->
+                            <execution>
+                                <id>yarn install</id>
+                                <goals>
+                                    <goal>yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>install</arguments>
+                                </configuration>
+                            </execution>
+                            <!-- Build the app -->
+                            <execution>
+                                <id>ng build</id>
+                                <goals>
+                                    <goal>yarn</goal>
+                                </goals>
+                                <phase>generate-resources</phase>
+                                <configuration>
+                                    <arguments>build</arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>productization</id>
+            <activation>
+                <property>
+                    <name>productization</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <executions>
+                            <!-- Install Node and Yarn -->
+                            <execution>
+                                <id>install node and yarn</id>
+                                <goals>
+                                    <goal>install-node-and-yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <nodeVersion>v6.11.2</nodeVersion>
+                                    <yarnVersion>v1.3.2</yarnVersion>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>set https proxy</id>
+                                <goals>
+                                    <goal>yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>config set https-proxy http://${buildContentId}+tracking:${accessToken}@${proxyServer}:${proxyPort}</arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>set http proxy</id>
+                                <goals>
+                                <goal>yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>config set proxy http://${buildContentId}+tracking:${accessToken}@${proxyServer}:${proxyPort}</arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>set maxconn</id>
+                                <goals>
+                                    <goal>yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>config set maxsockets 2</arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>yarn set registry</id>
+                                <goals>
+                                    <goal>yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>config set registry ${npmRegistryURL2}</arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>yarn set no-strict ssl</id>
+                                <goals>
+                                    <goal>yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>config set strict-ssl false</arguments>
+                                </configuration>
+                            </execution>
+                            <!-- Install npm/yarn dependencies -->
+                            <execution>
+                                <id>yarn install</id>
+                                <goals>
+                                    <goal>yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>install</arguments>
+                                </configuration>
+                            </execution>
+                            <!-- Build the app -->
+                            <execution>
+                                <id>ng build</id>
+                                <goals>
+                                    <goal>yarn</goal>
+                                </goals>
+                                <phase>generate-resources</phase>
+                                <configuration>
+                                    <arguments>build</arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>image</id>
             <activation>
                 <property>
@@ -168,6 +276,7 @@
                                     <descriptors>
                                         <descriptor>${project.basedir}/assembly-descriptors/linux-amd64.xml</descriptor>
                                     </descriptors>
+                                    <tarLongFileMode>posix</tarLongFileMode>
                                     <finalName>${project.name}-${project.version}</finalName>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
Please do not merge yet.     This adds two profiles - one for productization, another for non-productization use that reflect the differences in building the ui portions behind a proxy and free of one.