### PR TITLE
Use a version of node that exists in prod

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -160,7 +160,7 @@
                                     <goal>install-node-and-yarn</goal>
                                 </goals>
                                 <configuration>
-                                    <nodeVersion>v6.11.2</nodeVersion>
+                                    <nodeVersion>v6.11.5</nodeVersion>
                                     <yarnVersion>v1.3.2</yarnVersion>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
We need to use node 6.11.5 because prod doesn't have the files for 6.11.2