### PR TITLE
Need to add the yarnInheritsProxyConfigFromMaven to the prod profile 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <version.war.plugin>2.6</version.war.plugin>
         <version.exec.plugin>1.3.2</version.exec.plugin>
         <version.docker.plugin>0.11.2</version.docker.plugin>
-        <version.frontend-maven.plugin>1.6</version.frontend-maven.plugin>
+        <version.frontend-maven.plugin>1.7.6</version.frontend-maven.plugin>
         <version.scala-maven.plugin>3.2.2</version.scala-maven.plugin>
         <version.fabric8.maven.plugin>3.5.33</version.fabric8.maven.plugin>
 

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -228,6 +228,7 @@
                                 <phase>generate-resources</phase>
                                 <configuration>
                                     <arguments>build</arguments>
+                                    <yarnInheritsProxyConfigFromMaven>false</yarnInheritsProxyConfigFromMaven>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Need to add the yarnInheritsProxyConfigFromMaven to the prod profile to get apicurito to build in PNC.